### PR TITLE
Remove credentials from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
+# Workstation Back-End
+
+This project uses environment variables to configure the database connection string and JWT signing key. Sensitive values have been removed from the committed `appsettings.json` files.
+
+## Configuration
+
+A template configuration file is provided at `workstation-back-end/appsettings.Template.json`. Copy this file to `appsettings.json` (or `appsettings.Development.json`) and replace the placeholder values, or set the following environment variables:
+
+- `ConnectionStrings__DefaultConnection`
+- `Jwt__Key`
+
+### Render deployment
+
+When deploying to [Render](https://render.com), open your service, go to **Environment** and add the variables listed above. The application will read them at runtime.
 

--- a/workstation-back-end/appsettings.Template.json
+++ b/workstation-back-end/appsettings.Template.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": ""
+    "DefaultConnection": "<YOUR CONNECTION STRING>"
   },
   "port": 5000,
   "Logging": {
@@ -12,7 +12,7 @@
   "AllowedHosts": "*",
 
   "Jwt": {
-    "Key": "",
+    "Key": "<YOUR JWT KEY>",
     "Issuer": "workstation_back_end",
     "Audience": "workstation_back_end_users"
   }

--- a/workstation-back-end/appsettings.json
+++ b/workstation-back-end/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "server=sql10.freesqldatabase.com;user=sql10788038;password=iN9LpQ4HjW;database=sql10788038"
+    "DefaultConnection": ""
   },
   "port": 5000,
   "Logging": {
@@ -12,7 +12,7 @@
   "AllowedHosts": "*",
 
   "Jwt": {
-    "Key": "EstaEsUnaClaveSuperSecretaSegura123456", 
+    "Key": "", 
     "Issuer": "workstation_back_end",
     "Audience": "workstation_back_end_users"
   }


### PR DESCRIPTION
## Summary
- strip secrets from `appsettings.json` and `appsettings.Development.json`
- add `appsettings.Template.json` example
- document Render environment variables in README

## Testing
- `dotnet build workstation-back-end.sln` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686ed1c4f61c832e975f5a8aff0f7b7a