### PR TITLE
Add EF migrations guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
+## Database Migrations
 
+This project uses Entity Framework Core migrations. To add or update the
+database schema locally run:
+
+```bash
+dotnet ef migrations add <MigrationName> -o Migrations
+dotnet ef database update
+```
+
+The application automatically applies pending migrations at startup via
+`Database.Migrate()`.

--- a/workstation-back-end/Program.cs
+++ b/workstation-back-end/Program.cs
@@ -211,12 +211,12 @@ app.UseSwaggerUI();
 using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<TripMatchContext>();
-    context.Database.EnsureCreated();
+    // Apply pending migrations at startup
+    context.Database.Migrate();
 }
 
 app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseCors("_myAllowSpecificOrigins");
 app.UseAuthorization();
-app.MapControllers();
-app.Run();
+app.MapControllers();app.Run();


### PR DESCRIPTION
## Summary
- use `context.Database.Migrate()` instead of `EnsureCreated`
- document how to run EF Core migrations

## Testing
- `dotnet build workstation-back-end.csproj --no-restore` *(fails: .NET SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_686ed1c7bd00832eb9a5c1136881a683